### PR TITLE
macOS adaptions

### DIFF
--- a/sbb.sh
+++ b/sbb.sh
@@ -160,7 +160,14 @@ while getopts ":t:d:v:aiV" o; do
             ;;
         d)
             datestamp_raw=${OPTARG}
-            datestamp=$(date -d "$(echo $datestamp_raw | sed -r 's/([0-9]+)\.([0-9]+)\.([0-9]+)/\3-\2-\1/')" +"%d.%m.%Y")
+	    if [[ "$os" = Linux ]]; then
+		datestamp=$(date -d "$(echo $datestamp_raw | sed -r 's/([0-9]+)\.([0-9]+)\.([0-9]+)/\3-\2-\1/')" +"%d.%m.%Y")
+	    elif [[ "$os" = "macOS" ]]; then
+		datestamp=$(date -j -f "%Y-%m-%d" "$(echo $datestamp_raw | sed -E 's/([0-9]+)\.([0-9]+)\.([0-9]+)/\3-\2-\1/')" +"%d.%m.%Y")
+	    else
+		echo "Unkown OS"
+		exit 1
+	    fi
             ;;
         v)
             via=${OPTARG}

--- a/sbb.sh
+++ b/sbb.sh
@@ -31,25 +31,21 @@ function request_connection {
     
     resultJson=$(curl -s "$SBB_API_BASE?$queryString")
     
-    readarray connections < <(echo $resultJson | jq -r '.connections[].duration')
+    connections=$(echo $resultJson | jq -r '.connections[].duration' | wc -l)
 
-    i_connection=0
-    for connection in "${connections[@]}"
+    for (( i_connection=0; i_connection < connections; i_connection++ ))
     do
 	print_connection "$resultJson" ".connections[$i_connection]"
-	i_connection=$(expr $i_connection + 1)
     done
 }
 
 function print_connection {
     print_connection_header "$1" "$2"
 
-    readarray sections < <(echo $1 | jq -r "$2.sections[].walk")
-    i_section=0
-    for section in "${sections[@]}"
+    sections=$(echo $1 | jq -r "$2.sections[].walk" | wc -l)
+    for (( i_section=0; i_section < sections; i_section++ ))
     do
 	print_section "$1" "$2.sections[$i_section]" $i_section
-	i_section=$(expr $i_section + 1)
     done
 }
 

--- a/sbb.sh
+++ b/sbb.sh
@@ -31,21 +31,20 @@ function request_connection {
     
     resultJson=$(curl -s "$SBB_API_BASE?$queryString")
     
-    connections=$(echo $resultJson | jq -r '.connections[].duration' | wc -l)
-
-    for (( i_connection=0; i_connection < connections; i_connection++ ))
-    do
+    local i_connection=0
+    echo $resultJson | jq -r '.connections[].duration' | while read connection; do
 	print_connection "$resultJson" ".connections[$i_connection]"
+	(( i_connection++ ))
     done
 }
 
 function print_connection {
     print_connection_header "$1" "$2"
 
-    sections=$(echo $1 | jq -r "$2.sections[].walk" | wc -l)
-    for (( i_section=0; i_section < sections; i_section++ ))
-    do
+    local i_section=0
+    echo $1 | jq -r "$2.sections[].walk" | while read section; do
 	print_section "$1" "$2.sections[$i_section]" $i_section
+	(( i_section++ ))
     done
 }
 


### PR DESCRIPTION
- added support for macOS/BSD versions of `date` and `sed` (if `uname` returns "Darwin")
- removed dependency on `readarray` (which isn't available in `bash` as included in a standard macOS install)